### PR TITLE
Allow user to provide their own digest algorithm, remove sha3 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = [ "web-programming::http-client" ]
 default = [ "default-tls" ]
 
 tui = [ "indicatif" ]
-verify = [ "sha3" ]
+verify = [ "digest" ]
 
 # Pass down features to reqwest:
 default-tls = ["reqwest/default-tls"]
@@ -29,5 +29,8 @@ rand = { version = "0.8" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.1", features = [ "rt-multi-thread", "time" ] }
 
-indicatif = { version = "0.15", optional = true }
-sha3 = { version = "0.9", optional = true }
+digest = { version = "0.10.1", optional = true }
+indicatif = { version = "0.16.2", optional = true }
+
+[dev-dependencies]
+sha3 = "0.10.0"  # used in examples

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -58,16 +58,15 @@ pub fn noop() -> crate::Verify {
 // - SHA3:
 // ----------------------------------------------------------------------
 
-/// Make sure the downloaded file matches a SHA3 hash
+/// Make sure the downloaded file matches a provided hash using a provided Digest function
 #[cfg(feature = "verify")]
 #[must_use]
-pub fn sha3_256(hash: Vec<u8>) -> crate::Verify {
-    use sha3::Digest;
+pub fn with_digest<D: digest::Digest>(hash: Vec<u8>) -> crate::Verify {
     use std::io::Read;
 
     std::sync::Arc::new(
         move |path: std::path::PathBuf, cb: &crate::SimpleProgress| {
-            let mut hasher = sha3::Sha3_256::new();
+            let mut hasher = D::new();
 
             if let Ok(file) = std::fs::OpenOptions::new().read(true).open(&path) {
                 let mut reader = std::io::BufReader::with_capacity(1024 * 1024, file);


### PR DESCRIPTION
Let user use whichever implementation of `digest::Digest` they like.

closes #20 