### PR TITLE
Update check-jsonschema URL and version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,8 +46,8 @@ repos:
         -   mdformat-rustfmt
         -   mdformat-tables
         -   mdformat-web
--   repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.18.4
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.19.2
     hooks:
     -   id: check-github-workflows
     -   id: check-github-actions
@@ -61,5 +61,3 @@ ci:
   -   cargo-check
   -   clippy
   -   fmt
-  -   check-github-actions
-  -   check-github-workflows


### PR DESCRIPTION
👋 Hi, `check-jsonschema` maintainer here!

I'm doing some searches to try to find high-profile repos still using the old repo URL, so that we can get it updated across as many projects as possible.

I also enabled these in CI (previously skipped), as the `ci.skip` config appears to originate with a version of the hook which did not work in pre-commit.ci (v0.6.0 by the repo history).
Since v0.8.x , running in pre-commit.ci is supported and should work for you. But please let me know if you try it out and run into issues!