### PR TITLE
fix: running example on other OS

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -8,6 +8,8 @@
 #![warn(clippy::all, clippy::nursery, clippy::pedantic)]
 #![allow(clippy::non_ascii_literal)]
 
+use std::env::temp_dir;
+
 use downloader::Downloader;
 
 // Define a custom progress reporter:
@@ -70,7 +72,7 @@ impl downloader::progress::Reporter for SimpleReporter {
 
 fn main() {
     let mut downloader = Downloader::builder()
-        .download_folder(std::path::Path::new("/tmp"))
+        .download_folder(&temp_dir())
         .parallel_requests(1)
         .build()
         .unwrap();

--- a/examples/tui_basic.rs
+++ b/examples/tui_basic.rs
@@ -10,11 +10,12 @@
 #![allow(clippy::non_ascii_literal)]
 
 use downloader::Downloader;
+use std::env::temp_dir;
 
 // Run example with: cargo run --example tui_basic --features tui
 fn main() {
     let mut downloader = Downloader::builder()
-        .download_folder(std::path::Path::new("/tmp"))
+        .download_folder(&temp_dir())
         .parallel_requests(1)
         .build()
         .unwrap();


### PR DESCRIPTION
- use `std::env::temp_dir` instead of `/tmp`, to run example on other OS like windows